### PR TITLE
Relationships korrigiert

### DIFF
--- a/app/Client.php
+++ b/app/Client.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class Client extends Model
 {
-    public function answer()
+    public function answers()
     {
         return $this->hasMany('App\Answer');
     }

--- a/app/Question.php
+++ b/app/Question.php
@@ -17,7 +17,7 @@ class Question extends Model
         return $this->belongsTo('App\Topic');
     }
 
-    public function answer()
+    public function answers()
     {
         return $this->hasMany('App\Answer');
     }

--- a/app/Topic.php
+++ b/app/Topic.php
@@ -10,7 +10,7 @@ class Topic extends Model
     	'text',
     ];
 
-    public function topic()
+    public function questions()
     {
         return $this->hasMany('App\Question');
     }


### PR DESCRIPTION
Verwende bei `belongsToMany`/`hasMany` Relationships immer die Mehrzahl als Methodenname. So macht das Abfragen der Relationships auch mehr Sinn:

``` php
// Ein Client hat mehrere Antworten (hasMany)
Client::whereId(1)->answers()->get(); 
// vs.
Client::whereId(1)->answer()->get(); 
```
